### PR TITLE
added plastic for each disc on BagList and plastic option on DiscForm…

### DIFF
--- a/src/components/discs/BagList.css
+++ b/src/components/discs/BagList.css
@@ -19,7 +19,7 @@
     border: 5px solid #00bbdd;
     border-radius: 15px;
     background-color: rgba(245, 245, 245, 0.8);
-    height: 163px;
+    height: 186px;
     width: 330px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 8px 0 rgba(0, 0, 0, 0.19);
 }
@@ -73,6 +73,14 @@
 }
 
 .discManufacturer {
+    font-size: small;
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+    /* padding-bottom: 0.25rem; */
+}
+
+.discPlastic {
     font-size: small;
     display: flex;
     flex-direction: column;

--- a/src/components/discs/BagList.js
+++ b/src/components/discs/BagList.js
@@ -9,6 +9,7 @@ export const BagList = () => {
     const [discs, setDiscs] = useState([])
     const [usersDiscs, setUsersDiscs] = useState([])
     const [manufacturers, setManufacturers] = useState([])
+    const [plastics, setPlastics] = useState([])
 
     // assign the properties and values stored in disc_user in the localStorage in browser to a variable, which includes id and firstName for the user logged in
     const localDiscUser = localStorage.getItem("disc_user")
@@ -50,6 +51,18 @@ export const BagList = () => {
         [discs] // this useEffect is only triggered when there is a change in the discs array previously defined
     )
 
+    // useEffect to fetch plastics data from JSON and set state for plastics
+    useEffect(
+        () => {
+            fetch("http://localhost:8088/plastics")
+            .then(response => response.json())
+            .then((plasticArray) => {
+                setPlastics(plasticArray)
+            })
+        },
+        [] //empty array means it is observing initial component state
+    )
+
     // Defined a function to run a fetch call that only returns the objects in the ownedDiscs array that have the same userId as the currently logged in user and set the initial disc array with the returned data
     // This will be used in the delete function to trigger the useEffect previously defined to reset the state so the DOM reflects the deletion
     const getUsersDiscs = () => {
@@ -80,6 +93,12 @@ export const BagList = () => {
                                     {/* used conditional so the code only displays after the manufacturers array has fetched the data instead of in its inital empty array state */}
                                     {manufacturers.length > 0 && `Manufacturer:
                                         ${manufacturers.find(manufacturer => userDisc.disc.manufacturerId === manufacturer.id).name}
+                                    `}
+                                </div>
+                                <div className="discPlastic">
+                                    {/* used conditional so the code only displays after the manufacturers array has fetched the data instead of in its inital empty array state */}
+                                    {plastics.length > 0 && `Plastic:
+                                        ${plastics.find(plastic => userDisc.plasticId === plastic.id).name}
                                     `}
                                 </div>
                             </div>

--- a/src/components/discs/DiscForm.js
+++ b/src/components/discs/DiscForm.js
@@ -14,6 +14,8 @@ export const DiscForm = () => {
     const [manufacturers, setManufacturers] = useState([])
     const [discOptions, setDiscOptions] = useState([])
     const [discsFilteredByManufacturer, setFilteredDiscs] = useState([])
+    const [plastics, setPlastics] = useState([])
+    const [plasticsFilteredByManufacturer, setFilteredPlastics] = useState([])
 
     const navigate = useNavigate()
 
@@ -44,15 +46,50 @@ export const DiscForm = () => {
         []
     )
     
-    // useEffect to set state of discFilteredByManufacturer
+    // useEffect to set state of discsFilteredByManufacturer
     // used if conditional state to only run if the manufacturerId on the disc object is a value other than zero or a blank string
     // if conditions are met then discOptions is filtered to only return objects whose manufacturerId is equal to the disc object's manufacturerId
-    // used parseInt to chnage value from stribg to integer for conditional statement
+    // used parseInt to change value from stribg to integer for conditional statement
     useEffect(
         () => {
             if (disc.manufacturerId !== 0 && disc.manufacturerId !== "" ) {
                 const filteredDiscs = discOptions.filter(discOption => discOption.manufacturerId === parseInt(disc.manufacturerId))
+                // used .sort to list disc names in alphabetical order
+                filteredDiscs.sort((firstDisc, secondDisc) => {
+                    if (firstDisc.name < secondDisc.name) {
+                    return -1;
+                    }
+                    if (firstDisc.name > secondDisc.name) {
+                        return 1;
+                    }
+                    return 0;})
                 setFilteredDiscs(filteredDiscs)
+            }
+        },
+        [disc] //useEffect is only triggered if there is a change to the disc variable
+    )
+
+    // useEffect to fetch plastics data from JSON and set state for plastics
+    useEffect(
+        () => {
+            fetch("http://localhost:8088/plastics")
+            .then(response => response.json())
+            .then((plasticArray) => {
+                setPlastics(plasticArray)
+            })
+        },
+        [] //empty array means it is observing initial component state
+    )
+
+    // useEffect to set state of plasticFilteredByManufacturer
+    // used if conditional state to only run if the manufacturerId on the disc object is a value other than zero or a blank string
+    // if conditions are met then discOptions is filtered to only return objects whose manufacturerId is equal to the disc object's manufacturerId
+    // used parseInt to change value from stribg to integer for conditional statement
+    useEffect(
+        () => {
+            if (disc.manufacturerId !== 0 && disc.manufacturerId !== "" ) {
+                const filteredPlastics = plastics.filter(plastic => plastic.manufacturerId === parseInt(disc.manufacturerId))
+                setFilteredPlastics(filteredPlastics)
             }
         },
         [disc] //useEffect is only triggered if there is a change to the disc variable
@@ -67,6 +104,7 @@ export const DiscForm = () => {
         const discToSendToAPI = {
             userId: discUserObject.id,
             discId: parseInt(disc.discId),
+            plasticId: parseInt(disc.plasticId),
             weight: parseInt(disc.weight)
         }
 
@@ -113,7 +151,7 @@ export const DiscForm = () => {
                     </select>
                 </div>
             </fieldset>
-            {/* used conditional to only display field if the disc object's manufacturerId is not zero or an empty array, menaing it should only display once a manufacturer is selected */}
+            {/* used conditional to only display field if the disc object's manufacturerId is not zero or an empty array, meaning it should only display once a manufacturer is selected */}
             {disc.manufacturerId !== 0 && disc.manufacturerId !== "" && <fieldset>
                 <div className="form-group">
                     <label htmlFor="name">Model: </label>
@@ -133,6 +171,32 @@ export const DiscForm = () => {
                             discsFilteredByManufacturer.map(discFilteredByManufacturer => {
                                             return  <>
                                                 <option key={`disc--${discFilteredByManufacturer.id}`} value={discFilteredByManufacturer.id}>{discFilteredByManufacturer.name}</option>
+                                            </>
+                                            })
+                            }
+                    </select>
+                </div>
+            </fieldset>}
+            {/* used conditional to only display field if the disc object's manufacturerId is not zero or an empty array, meaning it should only display once a manufacturer is selected */}
+            {disc.manufacturerId !== 0 && disc.manufacturerId !== "" && <fieldset>
+                <div className="form-group">
+                    <label htmlFor="plastic">Plastic: </label>
+                    <select
+                        value={disc.plasticId}
+                        required
+                        className="form-control"
+                        onChange={
+                            (event) => {
+                                const copy = {...disc}
+                                copy.plasticId = event.target.value
+                                update(copy)
+                            }
+                        }>
+                            <option value="">Select plastic...</option>
+                            {
+                            plasticsFilteredByManufacturer.map(plasticFilteredByManufacturer => {
+                                            return  <>
+                                                <option key={`plastic--${plasticFilteredByManufacturer.id}`} value={plasticFilteredByManufacturer.id}>{plasticFilteredByManufacturer.name}</option>
                                             </>
                                             })
                             }


### PR DESCRIPTION
…. sorted disc option on DiscForm alphabetically

1. Added a display field for the disc's plastic on BagList.

This can be tested by opening application and navigating to '/myBag' to see plastic field on each disc.

2. Added the option to choose the disc's plastic on DiscForm. Disc model is now sorted alphabetically as well.

This can be tested by navigating to '/addDisc' and selecting a manufacturer. Model and Plastic options will appear.